### PR TITLE
Add readme update and optional plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A **Python implementation** of David Deutsch’s Constructor Theory framework, e
   * Lorentz-force (2D) for charged particles in a magnetic field
 * **Quantum-Gravity & Electromagnetism**: Graviton & Photon emission/absorption Tasks
 * **UniversalConstructor**: Bootstraps any list of Tasks into a working Constructor
+* **Hydrogen atom constructors**: Excitation, deexcitation and two-atom collisions
 * **Demo scripts**:
 
   * `demo.py` – shows every constructor in action

--- a/ct_tests.py
+++ b/ct_tests.py
@@ -407,5 +407,37 @@ class TestCTFramework(unittest.TestCase):
         self.assertEqual(out_B.Bz, B.Bz)
 
 
+    # 38. Hydrogen atom excitation and deexcitation
+    def test_hydrogen_excitation_cycle(self):
+        gap = 10.2
+        cons = ctf.HydrogenAtomConstructor(gap)
+        h = ctf.Substrate("H", ctf.HYDROGEN_GROUND, energy=0.0)
+        excited = cons.perform(h)[0]
+        self.assertEqual(excited.attr, ctf.HYDROGEN_EXCITED)
+        self.assertAlmostEqual(excited.energy, gap, places=6)
+        worlds = cons.perform(excited)
+        attrs = {w.attr for w in worlds}
+        self.assertIn(ctf.HYDROGEN_GROUND, attrs)
+        self.assertIn(ctf.PHOTON, attrs)
+
+    # 39. Hydrogen collision leading to molecule
+    def test_hydrogen_collision_bond(self):
+        hi = ctf.HydrogenInteractionConstructor(bond_energy=4.5)
+        h1 = ctf.Substrate("h1", ctf.HYDROGEN_GROUND, energy=3.0)
+        h2 = ctf.Substrate("h2", ctf.HYDROGEN_GROUND, energy=3.0)
+        result = hi.perform([h1, h2])[0]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].attr, ctf.HYDROGEN_MOLECULE)
+
+    # 40. Hydrogen collision insufficient energy
+    def test_hydrogen_collision_no_bond(self):
+        hi = ctf.HydrogenInteractionConstructor(bond_energy=4.5)
+        h1 = ctf.Substrate("ha", ctf.HYDROGEN_GROUND, energy=1.0)
+        h2 = ctf.Substrate("hb", ctf.HYDROGEN_GROUND, energy=1.0)
+        result = hi.perform([h1, h2])[0]
+        self.assertEqual(len(result), 2)
+        self.assertEqual({s.attr for s in result}, {ctf.HYDROGEN_GROUND})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,9 @@
 import time
 import math
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:  # pragma: no cover - optional plotting
+    plt = None
 
 
 from ct_framework import (
@@ -36,6 +39,12 @@ from ct_framework import (
     # Lorentz-force imports
     FieldSubstrate,
     lorentz_coupling_fn,
+    # Hydrogen imports
+    HYDROGEN_GROUND,
+    HYDROGEN_EXCITED,
+    HYDROGEN_MOLECULE,
+    HydrogenAtomConstructor,
+    HydrogenInteractionConstructor,
 )
 
 
@@ -194,13 +203,16 @@ def demo_2d_orbit(integrator, steps=100):
         sat = integrator.apply(sat)[0]
         xs.append(sat.x)
         ys.append(sat.y)
-    plt.figure(figsize=(5, 5))
-    plt.plot(xs, ys, "-", lw=1)
-    plt.scatter([0], [0], color="red", s=30, label="Center")
-    plt.axis("equal")
-    plt.title("2D Orbit")
-    plt.legend()
-    plt.show()
+    if plt is None:
+        print("matplotlib not available; skipping 2D orbit plot.")
+    else:
+        plt.figure(figsize=(5, 5))
+        plt.plot(xs, ys, "-", lw=1)
+        plt.scatter([0], [0], color="red", s=30, label="Center")
+        plt.axis("equal")
+        plt.title("2D Orbit")
+        plt.legend()
+        plt.show()
     print()
 
 
@@ -265,6 +277,31 @@ def demo_lorentz_force():
     print()
 
 
+def demo_hydrogen_atom():
+    print("=== Hydrogen Atom Demo ===")
+    cons = HydrogenAtomConstructor()
+    h = Substrate("H", HYDROGEN_GROUND, energy=0.0)
+    excited = cons.perform(h)[0]
+    print("After excitation:", excited)
+    for w in cons.perform(excited):
+        print(" ", w)
+    print()
+
+
+def demo_hydrogen_collision():
+    print("=== Hydrogen Collision Demo ===")
+    hi = HydrogenInteractionConstructor()
+    h1 = Substrate("H1", HYDROGEN_GROUND, energy=3.0)
+    h2 = Substrate("H2", HYDROGEN_GROUND, energy=3.0)
+    result = hi.perform([h1, h2])[0]
+    for r in result:
+        print(" ", r)
+    low1 = Substrate("hA", HYDROGEN_GROUND, energy=1.0)
+    low2 = Substrate("hB", HYDROGEN_GROUND, energy=1.0)
+    print("Low energy outcome:", hi.perform([low1, low2])[0])
+    print()
+
+
 if __name__ == "__main__":
     demo_task_constructor()
     demo_action_constructor()
@@ -282,3 +319,5 @@ if __name__ == "__main__":
     demo_photon_emission_absorption()
     demo_coulomb_coupling()
     demo_lorentz_force()
+    demo_hydrogen_atom()
+    demo_hydrogen_collision()


### PR DESCRIPTION
## Summary
- update features list in README for hydrogen constructors
- make matplotlib optional in demo
- skip 2D orbit plots if matplotlib is missing

## Testing
- `python -m unittest ct_tests.py`
- `python demo.py`